### PR TITLE
Implement CommandService

### DIFF
--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Aliases.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Aliases.java
@@ -1,0 +1,14 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Aliases {
+
+    String[] value();
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Children.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Children.java
@@ -1,0 +1,14 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Children {
+
+    Class<? extends Command>[] value();
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Command.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Command.java
@@ -1,0 +1,64 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+
+public abstract class Command implements CommandExecutor {
+
+    private final ImmutableList<CommandElement> arguments;
+    private final ImmutableList<Class<? extends Command>> children;
+    private final ImmutableList<String> aliases;
+    private final Optional<String> permission;
+    private final Optional<Text> description;
+    private final CommandSpec spec;
+
+    protected Command(CommandService service, Settings settings) {
+        arguments = settings.arguments != null ? ImmutableList.copyOf(settings.arguments) : ImmutableList.of();
+        children = settings.children != null ? ImmutableList.copyOf(settings.children) : getClass().isAnnotationPresent(Children.class) ? ImmutableList.copyOf(getClass().getAnnotation(Children.class).value()) : ImmutableList.of();
+        aliases = settings.aliases != null ? ImmutableList.copyOf(settings.aliases) : getClass().isAnnotationPresent(Aliases.class) ? ImmutableList.copyOf(getClass().getAnnotation(Aliases.class).value()) : ImmutableList.of();
+        permission = settings.permission != null ? Optional.of(settings.permission) : getClass().isAnnotationPresent(Permission.class) ? Optional.of(getClass().getAnnotation(Permission.class).value()) : Optional.empty();
+        description = settings.description != null ? Optional.of(settings.description) : getClass().isAnnotationPresent(Description.class) ? Optional.of(Text.of(getClass().getAnnotation(Description.class).value())) : Optional.empty();
+        CommandSpec.Builder builder = CommandSpec.builder().executor(this);
+        if (!arguments.isEmpty()) {
+            builder.arguments(arguments.size() == 1 ? arguments.get(0) : GenericArguments.seq(settings.arguments));
+        }
+        for (Class<? extends Command> child : children) {
+            Command command = service.getInstance(child);
+            builder.child(command.spec, command.aliases);
+        }
+        permission.ifPresent(builder::permission);
+        description.ifPresent(builder::description);
+        this.spec = builder.build();
+    }
+
+    public ImmutableList<CommandElement> getArguments() {
+        return arguments;
+    }
+
+    public ImmutableList<Class<? extends Command>> getChildren() {
+        return children;
+    }
+
+    public ImmutableList<String> getAliases() {
+        return aliases;
+    }
+
+    public Optional<String> getPermission() {
+        return permission;
+    }
+
+    public Optional<Text> getDescription() {
+        return description;
+    }
+
+    public CommandSpec getSpec() {
+        return spec;
+    }
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/CommandService.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/CommandService.java
@@ -1,0 +1,44 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.plugin.PluginContainer;
+
+public class CommandService {
+
+    private final Injector injector;
+    private final PluginContainer container;
+
+    private CommandService(PluginContainer container) {
+        this.injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(CommandService.class).toInstance(CommandService.this);
+            }
+        });
+        this.container = container;
+    }
+
+    public static CommandService of(PluginContainer container) {
+        return new CommandService(container);
+    }
+
+    public <T extends Command> T getInstance(Class<T> clazz) {
+        return injector.getInstance(clazz);
+    }
+
+    public void register(Class<? extends Command> clazz) {
+        Command command = injector.getInstance(clazz);
+        Sponge.getCommandManager().register(container, command.getSpec(), command.getAliases());
+    }
+
+    @SafeVarargs
+    public final void register(Class<? extends Command>... classes) {
+        for (Class<? extends Command> clazz : classes) {
+            register(clazz);
+        }
+    }
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Description.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Description.java
@@ -1,0 +1,14 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Description {
+
+    String value();
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Permission.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Permission.java
@@ -1,0 +1,14 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Permission {
+
+    String value();
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Settings.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/command/Settings.java
@@ -1,0 +1,48 @@
+package com.mcsimonflash.sponge.teslalibs.command;
+
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+
+public class Settings {
+
+    @Nullable CommandElement[] arguments;
+    @Nullable Class<? extends Command>[] children;
+    @Nullable String[] aliases;
+    @Nullable String permission;
+    @Nullable Text description;
+
+    private Settings() {}
+
+    public static Settings create() {
+        return new Settings();
+    }
+
+    public Settings arguments(CommandElement... arguments) {
+        this.arguments = arguments;
+        return this;
+    }
+
+    @SafeVarargs
+    public final Settings children(Class<? extends Command>... children) {
+        this.children = children;
+        return this;
+    }
+
+    public Settings aliases(String... aliases) {
+        this.aliases = aliases;
+        return this;
+    }
+
+    public Settings permission(String permission) {
+        this.permission = permission;
+        return this;
+    }
+
+    public Settings description(Text description) {
+        this.description = description;
+        return this;
+    }
+
+}


### PR DESCRIPTION
This PR implements the `CommandService` and the base of the command library. The primary goal of this feature is to have a lightweight system for structuring commands and storing `CommandSpec`s, aliases, or even command instances.

***

### CommandService
The `CommandService` is the controller class for initializing and storing commands using a Guice `Injector`. Utility methods for retrieving a command instance and registering commands are also available.

### Command Library
The main library consists of three parts: the `Command` class for declaring commands, the `Settings` class for advanced settings, and multiple annotations for basic settings.

#### Example
```java
@Children(SubCommand.class)
@Aliases({"test", "test2"})
@Permission("teslalibs.command.test")
public class TestCommand extends Command {
    
    @Inject
    protected TestCommand(CommandService service) {
        super(service, Settings.create()
                .arguments(GenericArguments.player(Text.of("player"))));
    }

}
```
Annotations only support primatives and `String`s, so other classes such as `CommandElement`s are handled through the `Settings` class, which is similar to a builder. All annotations have `Settings` counterparts.

Instances of child commands are retrieved from the `CommandService` which injects itself into the constructor. As a result, all constructors must have a single `CommandService` parameter and be annotated with Guice's `@Inject`. Classes that might be injected more than once (such as a command with multiple parents) should be annotated with `@Singleton` so the same instance is returned.

***

I'll be working on adding javadocs to everything over the next couple days, and I'd like to merge this request this weekend. If you could leave some feedback below on this system that'd be great!