### PR TITLE
Refactor Inventory Library

### DIFF
--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Action.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Action.java
@@ -1,0 +1,59 @@
+package com.mcsimonflash.sponge.teslalibs.inventory;
+
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.item.inventory.ClickInventoryEvent;
+import org.spongepowered.api.event.item.inventory.InteractInventoryEvent;
+import org.spongepowered.api.item.inventory.Slot;
+
+public class Action<T extends InteractInventoryEvent> {
+
+    private final T event;
+    private final Player player;
+
+    Action(T event, Player player) {
+        this.event = event;
+        this.player = player;
+    }
+
+    /**
+     * @return the event of the click
+     */
+    public T getEvent() {
+        return event;
+    }
+
+    /**
+     * @return the player that caused this click
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    public static class Click<T extends ClickInventoryEvent> extends Action<T> {
+
+        private final Element element;
+        private final Slot slot;
+
+        Click(T event, Player player, Element element, Slot slot) {
+            super(event, player);
+            this.element = element;
+            this.slot = slot;
+        }
+
+        /**
+         * @return the element processing this click
+         */
+        public Element getElement() {
+            return element;
+        }
+
+        /**
+         * @return the slot clicked
+         */
+        public Slot getSlot() {
+            return slot;
+        }
+
+    }
+
+}

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Element.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Element.java
@@ -26,7 +26,7 @@ public class Element {
      * @see Element.Builder methods
      */
     public static Element of(ItemStack item, Consumer<Action.Click> clickAction) {
-        return builder().item(item).click(clickAction).build();
+        return builder().item(item).onClick(clickAction).build();
     }
 
     /**
@@ -84,7 +84,7 @@ public class Element {
         /**
          * Sets the click action that is accepted when this element is clicked.
          */
-        public Builder click(Consumer<Action.Click> clickAction) {
+        public Builder onClick(Consumer<Action.Click> clickAction) {
             this.clickAction = clickAction;
             return this;
         }

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Element.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Element.java
@@ -1,61 +1,39 @@
 package com.mcsimonflash.sponge.teslalibs.inventory;
 
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.function.Consumer;
 
-/* TODO:
- * Is there a need to have simplified methods to handle common consumers such
- * as process commands, open new views, etc.
- */
-/* TODO:
- * Some GUI cases, such as a trade window, would need to allow players to edit
- * certain slots. Is this something feasible for this project, and if so how
- * should we go about determining who can edit a slot?
- *
- * Because this would need to be player specific, we'd likely have to have a
- * Function<Player, Boolean> to return whether the given Player can edit the
- * slot and cancel (or not) the event accordingly.
- *
- * An alternative is to consider having two independent views, and requiring a
- * simultaneous update of each.
- */
 public class Element {
 
-    public static final Element EMPTY = of(ItemStack.empty());
+    public static final Element EMPTY = builder().build();
 
     private final ItemStackSnapshot item;
-    private final Consumer<Player> consumer;
+    private final Consumer<Action.Click> clickAction;
 
     /**
-     * @see #of(ItemStack, Consumer)
+     * @see Element#of(ItemStack, Consumer)
      */
-    private Element(ItemStackSnapshot item, Consumer<Player> consumer) {
+    private Element(ItemStackSnapshot item, Consumer<Action.Click> clickAction) {
         this.item = item;
-        this.consumer = consumer;
+        this.clickAction = clickAction;
     }
 
     /**
-     * Creates a new Element with the given item and consumer.
+     * Creates a new {@link Element} with the given item and click action
      *
-     * @param item the item displayed for this element
-     * @param consumer the consumer when this element is clicked
-     * @return the newly created element
+     * @see Element.Builder methods
      */
-    public static Element of(ItemStack item, Consumer<Player> consumer) {
-        return new Element(item.createSnapshot(), consumer);
+    public static Element of(ItemStack item, Consumer<Action.Click> clickAction) {
+        return builder().item(item).click(clickAction).build();
     }
 
     /**
-     * Creates a new Element with the given item and an empty consumer
-     *
-     * @param item the item displayed for this element
-     * @return the newly created element
+     * Creates a new {@link Element} with the given item and no click.
      */
     public static Element of(ItemStack item) {
-        return new Element(item.createSnapshot(), player -> {});
+        return builder().item(item).build();
     }
 
     /**
@@ -66,14 +44,58 @@ public class Element {
     }
 
     /**
-     * Accepts the consumer for a given player. This method is called when an
-     * {@link org.spongepowered.api.event.item.inventory.ClickInventoryEvent}
-     * is registered for a slot with this element by the player.
-     *
-     * @param player the player who clicked on the slot
+     * Processes this elements click action with the given {@link Action.Click}.
      */
-    public void process(Player player) {
-        consumer.accept(player);
+    public void process(Action.Click action) {
+        this.clickAction.accept(action);
+    }
+
+    /**
+     * Creates a new builder for creating an {@link Element}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private static final Consumer<Action.Click> DEFAULT = a -> {};
+
+        private ItemStackSnapshot item = ItemStackSnapshot.NONE;
+        private Consumer<Action.Click> clickAction = DEFAULT;
+
+        /**
+         * Sets the item to be the given {@link ItemStackSnapshot}.
+         */
+        public Builder item(ItemStackSnapshot item) {
+            this.item = item;
+            return this;
+        }
+
+        /**
+         * Sets the item to be a snapshot of the give {@link ItemStack}.
+         *
+         * @see Element.Builder#item(ItemStackSnapshot)
+         */
+        public Builder item(ItemStack item) {
+            return item(item.createSnapshot());
+        }
+
+        /**
+         * Sets the click action that is accepted when this element is clicked.
+         */
+        public Builder click(Consumer<Action.Click> clickAction) {
+            this.clickAction = clickAction;
+            return this;
+        }
+
+        /**
+         * @return the created element
+         */
+        public Element build() {
+            return new Element(item, clickAction);
+        }
+
     }
 
 }

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Layout.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Layout.java
@@ -3,225 +3,180 @@ package com.mcsimonflash.sponge.teslalibs.inventory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.spongepowered.api.item.inventory.property.InventoryDimension;
 
 import java.util.Collection;
 import java.util.Map;
 
-/* TODO:
- * Layouts will be required to have an InventoryDimension
- */
 public class Layout {
 
     private final ImmutableMap<Integer, Element> elements;
+    private final InventoryDimension dimension;
 
     /**
-     * Creates a new layout
-     *
-     * @param elements the elements
+     * Creates a new {@link Layout} representing a map of elements to set
+     * indices within an inventory.
      */
-    private Layout(Map<Integer, Element> elements) {
-        this.elements = ImmutableMap.copyOf(elements);
+    private Layout(ImmutableMap<Integer, Element> elements, InventoryDimension dimension) {
+        this.elements = elements;
+        this.dimension = dimension;
     }
 
     /**
-     * Retrieves an element at a given index
-     *
-     * @param index the index correlating to the slotindex
-     * @return the element at that index or an empty element
+     * Retrieves an element at a given index in the layout. If the index is not
+     * present in the map of elements, {@link Element#EMPTY} is returned.
      */
-    public Element getElement(Integer index) {
+    public Element getElement(int index) {
         return elements.getOrDefault(index, Element.EMPTY);
     }
 
     /**
-     * Retrieves the map of elements. This map is immutable.
-     *
-     * @return the map of elements.
+     * @return the immutable map of elements
      */
     public ImmutableMap<Integer, Element> getElements() {
         return elements;
     }
 
     /**
-     * Creates a new builder for building layouts.
-     *
-     * @return the builder
+     * @return the layout dimension
+     */
+    public InventoryDimension getDimension() {
+        return dimension;
+    }
+
+    /**
+     * Creates a new builder for creating a {@link Layout}.
      */
     public static Builder builder() {
         return new Builder();
     }
 
-    /**
-     * A builder for creating layouts
-     */
     public static class Builder {
 
-        private Map<Integer, Element> elements = Maps.newHashMap();
-        private int width;
-        private int height;
-        private int size;
+        private static final InventoryDimension DEFAULT = InventoryDimension.of(9, 6);
 
-        private void checkSize() {
-            Preconditions.checkArgument(size != 0, "Layout dimension must be defined.");
-        }
+        private Map<Integer, Element> elements = Maps.newHashMap();
+        private InventoryDimension dimension = DEFAULT;
+        private int rows = 6;
+        private int columns = 9;
+        private int capacity = 54;
 
         /**
-         * Defines this layout to have the given dimension.
+         * Sets the dimension to be the given {@link InventoryDimension}. The
+         * dimension is used for advanced set methods, ensuring {@link Element}s
+         * are in the bounds of the layout, and ensuring a layout of the proper
+         * dimension is being applied to an {@link View}.
          *
-         * @param width the width
-         * @param height the height
-         * @return this builder
+         * By default, the dimension is a double chest (6 by 9).
          */
-        public Builder dimension(int width, int height) {
-            this.width = width;
-            this.height = height;
-            this.size = width * height;
+        public Builder dimension(InventoryDimension dimension) {
+            this.dimension = dimension;
+            rows = dimension.getRows();
+            columns = dimension.getColumns();
+            capacity = rows * columns;
             return this;
         }
 
         /**
-         * Registers the given element at the given index.
-         *
-         * @param index the index in the inventory
-         * @param element the element
-         * @return this builder
+         * Sets the element at the given index. The index must be at least 0 and
+         * less than the capacity or an {@link IndexOutOfBoundsException} will
+         * be thrown.
          */
-        public Builder slot(Element element, int index) {
+        public Builder set(Element element, int index) {
+            Preconditions.checkElementIndex(index, capacity);
             elements.put(index, element);
             return this;
         }
 
         /**
-         * Registers the given element at the given indices.
-         *
-         * @param element the element
-         * @param indices the indices in the inventory
-         * @return this builder
+         * Sets the element at the given indices.
          */
-        public Builder slots(Element element, int... indices) {
+        public Builder set(Element element, int... indices) {
             for (int i : indices) {
-                slot(element, i);
+                set(element, i);
             }
             return this;
         }
 
         /**
-         * Registers all index/element entries in the given map.
-         *
-         * @param elements the map of elements
-         * @return this builder
+         * Sets all of the elements defined in the map to their assigned index.
          */
-        public Builder slots(Map<Integer, Element> elements) {
-            this.elements.putAll(elements);
+        public Builder setAll(Map<Integer, Element> elements) {
+            for (Map.Entry<Integer, Element> entry : elements.entrySet()) {
+                set(entry.getValue(), entry.getKey());
+            }
             return this;
         }
 
         /**
-         * Registers the given element for every index in the given row.
-         *
-         * @param element the element
-         * @param index the index of the row
-         * @return this builder
-         * @throws IllegalArgumentException if the dimension is undefined
+         * Sets the element to all of the indices in the given row.
          */
         public Builder row(Element element, int index) {
-            checkSize();
-            for (int i = width * index; i < width * (index + 1); i++) {
-                slot(element, i);
+            for (int i = columns * index; i < columns * (index + 1); i++) {
+                set(element, i);
             }
             return this;
         }
 
         /**
-         * Registers the given element at each index in the given column.
-         *
-         * @param element the element
-         * @param index the index of the column
-         * @return this builder
-         * @throws IllegalArgumentException if the dimension is undefined
+         * Sets the element to all of the indices in the given column.
          */
         public Builder column(Element element, int index) {
-            checkSize();
-            for (int i = index; i < size; i += width) {
-                slot(element, i);
+            for (int i = index; i < capacity; i += columns) {
+                set(element, i);
             }
             return this;
         }
 
         /**
-         * Registers the given element at the center of this layout, defined by
-         * {@code size / 2}.
-         *
-         * @param element the element
-         * @return this builder
-         * @throws IllegalArgumentException if the dimension is undefined
+         * Sets the element to the index defined by {code capacity / 2}.
          */
         public Builder center(Element element) {
-            checkSize();
-            return slot(element, size / 2);
+            return set(element, capacity / 2);
         }
 
         /**
-         * Creates a border using the given element.
-         *
-         * @param element the element
-         * @return this builder
-         * @throws IllegalArgumentException if the dimension is undefined
+         * Sets the element to all indices along the border of the layout.
          */
         public Builder border(Element element) {
-            checkSize();
-            for (int i = 0; i <= width; i++) {
-                slot(element, i);
-                slot(element, size - i);
+            for (int i = 0; i <= columns; i++) {
+                set(element, i);
+                set(element, capacity - i);
             }
-            for (int i = 2; i < height - 1; i++) {
-                int j = i * width;
-                slot(element, j - 1);
-                slot(element, j);
+            for (int i = 2; i < rows - 1; i++) {
+                int j = i * columns;
+                set(element, j - 1);
+                set(element, j);
             }
             return this;
         }
 
         /**
-         * Creates a checkerboard from the given elements
-         *
-         * @param even the element at even slot indices
-         * @param odd the element at odd slot indices
-         * @return this builder
-         * @throws IllegalArgumentException if the dimension is undefined
+         * Creates a checkerboard from the given even and odd elements.
          */
         public Builder checker(Element even, Element odd) {
-            checkSize();
-            for (int i = 0; i < size; i++) {
-                slot(i % 2 == 0 ? even : odd, i);
+            for (int i = 0; i < capacity; i++) {
+                set(i % 2 == 0 ? even : odd, i);
             }
             return this;
         }
 
         /**
-         * Fills any unregistered slots with the given element
-         *
-         * @param element the element
-         * @return this builder
-         * @throws IllegalArgumentException if the dimension is undefined
+         * Fills any unregistered slots with the given element.
          */
         public Builder fill(Element element) {
-            checkSize();
-            for (int i = 0; i < size; i++) {
+            for (int i = 0; i < capacity; i++) {
                 if (!elements.containsKey(i)) {
-                    slot(element, i);
+                    set(element, i);
                 }
             }
             return this;
         }
 
         /**
-         * Pages the given elements through the layout in the order of the slot
+         * Pages the given elements through the layout in the order of the set
          * index and natural ordering of the collection. Indexes that are
          * already registered will be skipped.
-         *
-         * @param elements the collection of elements
-         * @return this builder
          */
         public Builder page(Collection<Element> elements) {
             int index = 0;
@@ -229,18 +184,14 @@ public class Layout {
                 while (this.elements.containsKey(index)) {
                     index++;
                 }
-                slot(element, index++);
+                set(element, index++);
             }
             return this;
         }
 
         /**
          * Replaces instances of the initial element with the replacement. This
-         * method is primarily used with layout templates as in pages.
-         *
-         * @param initial the initial element
-         * @param replacement the replacement element
-         * @return this builder
+         * method is primarily for layout templates as used with {@link Page}s.
          */
         public Builder replace(Element initial, Element replacement) {
             for (Map.Entry<Integer, Element> entry : elements.entrySet()) {
@@ -252,33 +203,10 @@ public class Layout {
         }
 
         /**
-         * Registers all elements contained in the given layout, replacing if
-         * necessary.
-         *
-         * @param layout the layout
-         * @return this builder
-         */
-        public Builder from(Layout layout) {
-            return slots(layout.getElements());
-        }
-
-        /**
-         * Clears all registered elements.
-         *
-         * @return this builder
-         */
-        public Builder reset() {
-            elements.clear();
-            return this;
-        }
-
-        /**
-         * Builds the layout represented by this builder
-         *
-         * @return the newly created layout
+         * @return the created layout
          */
         public Layout build() {
-            return new Layout(elements);
+            return new Layout(ImmutableMap.copyOf(elements), dimension);
         }
 
     }

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Layout.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Layout.java
@@ -203,6 +203,16 @@ public class Layout {
         }
 
         /**
+         * Copies the dimension and elements of the given layout to this one.
+         */
+        public Builder from(Layout layout) {
+            elements.clear();
+            dimension(layout.getDimension());
+            setAll(layout.getElements());
+            return this;
+        }
+
+        /**
          * @return the created layout
          */
         public Layout build() {

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Page.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Page.java
@@ -1,83 +1,146 @@
 package com.mcsimonflash.sponge.teslalibs.inventory;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.ItemTypes;
-import org.spongepowered.api.item.inventory.InventoryArchetypes;
-import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.*;
+import org.spongepowered.api.item.inventory.property.AbstractInventoryProperty;
+import org.spongepowered.api.item.inventory.property.InventoryCapacity;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
 
-import java.util.LinkedList;
 import java.util.List;
 
 public class Page {
 
-    public static final Element FIRST = Element.of(ItemStack.empty());
-    public static final Element LAST = Element.of(ItemStack.empty());
-    public static final Element NEXT = Element.of(ItemStack.empty());
-    public static final Element PREVIOUS = Element.of(ItemStack.empty());
-    public static final Element CURRENT = Element.of(ItemStack.empty());
+    public static final Element FIRST = Element.builder().build();
+    public static final Element LAST = Element.builder().build();
+    public static final Element NEXT = Element.builder().build();
+    public static final Element PREVIOUS = Element.builder().build();
+    public static final Element CURRENT = Element.builder().build();
 
-    private LinkedList<View> views = Lists.newLinkedList();
-    private Layout template;
-    private PluginContainer container;
+    private final List<View> views = Lists.newArrayList();
+    private final InventoryArchetype archetype;
+    private final ImmutableList<InventoryProperty> properties;
+    private final Layout layout;
+    private final PluginContainer container;
 
     /**
-     * @see #of(Layout, PluginContainer)
+     * @see Page#of(Layout, InventoryArchetype, PluginContainer)
      */
-    public Page(Layout template, PluginContainer container) {
-        this.template = template;
+    private Page(InventoryArchetype archetype, ImmutableList<InventoryProperty> properties, Layout layout, PluginContainer container) {
+        this.archetype = archetype;
+        this.properties = properties;
+        this.layout = layout;
         this.container = container;
     }
 
     /**
-     * Creates a new Page with the given template for the given container.
+     * Creates a new {@link Page} using the given layout as the template and
+     * archetype for creating the backing {@link View}s.
      *
-     * @param template the page template
-     * @param container the container creating this page
-     * @return the new page
+     * @see Page.Builder methods
      */
-    public static Page of(Layout template, PluginContainer container) {
-        return new Page(template, container);
+    public Page of(Layout layout, InventoryArchetype archetype, PluginContainer container) {
+        return Page.builder().layout(layout).archetype(archetype).build(container);
     }
 
     /**
-     * Defines this page to contain the given elements. The implementation
-     * currently assumes that the layout contains 54 slots (double chest); this
-     * will be changed in a future version.
-     *
-     * @param elements the list of elements
-     * @return this page
+     * Defines this page to contain the given elements. The number of pages is
+     * expanded as need be to fill the size of the elements.
      */
     public Page define(List<Element> elements) {
         views.clear();
-        int pages = elements.size() != 0 ? elements.size() / (54 - template.getElements().size()) : 1;
+        int capacity = archetype.getProperty(InventoryCapacity.class)
+                .map(AbstractInventoryProperty::getValue)
+                .orElse(54) - layout.getElements().size();
+        int pages = elements.isEmpty() ? 1 : elements.size() / capacity + 1;
         for (int i = 1; i <= pages; i++) {
-            views.add(View.of(InventoryArchetypes.DOUBLE_CHEST, container));
-        }
-        for (int i = 1; i <= pages; i++) {
-            views.get(i - 1).define(Layout.builder()
-                    .from(template)
-                    .replace(FIRST, Element.of(ItemStack.builder().itemType(i == 1 ? ItemTypes.MAP : ItemTypes.PAPER).quantity(1).add(Keys.DISPLAY_NAME, Text.of("First")).build(), i == 1 ? p -> {} : views.get(0)::open))
-                    .replace(LAST, Element.of(ItemStack.builder().itemType(i == pages ? ItemTypes.MAP : ItemTypes.PAPER).quantity(pages).add(Keys.DISPLAY_NAME, Text.of("Last")).build(), i == pages ? p -> {} : views.get(pages - 1)::open))
-                    .replace(NEXT, Element.of(ItemStack.builder().itemType(i == pages ? ItemTypes.MAP : ItemTypes.PAPER).quantity(i == pages ? i : i + 1).add(Keys.DISPLAY_NAME, Text.of("Next")).build(), i == pages ? p -> {} : views.get(i)::open))
-                    .replace(PREVIOUS, Element.of(ItemStack.builder().itemType(i == 1 ? ItemTypes.MAP : ItemTypes.PAPER).quantity(i == 1 ? i : i - 1).add(Keys.DISPLAY_NAME, Text.of("Previous")).build(), i == 1 ? p -> {} : views.get(i - 2)::open))
-                    .replace(CURRENT, Element.of(ItemStack.builder().itemType(ItemTypes.MAP).quantity(i).add(Keys.DISPLAY_NAME, Text.of("Current")).build()))
-                    .page(elements.subList((i - 1) * (54 - template.getElements().size()), i == pages ? elements.size() : (i) * (54 - template.getElements().size())))
-                    .build());
+            View.Builder builder = View.builder().archetype(archetype);
+            properties.forEach(builder::property);
+            views.add(builder.build(container).define(Layout.builder()
+                    .dimension(layout.getDimension())
+                    .setAll(layout.getElements())
+                    .replace(FIRST, createElement("First Page", i, 1))
+                    .replace(LAST, createElement("Last Page", i, pages))
+                    .replace(NEXT, createElement("Next Page", i, i == pages ? i : i + 1))
+                    .replace(PREVIOUS, createElement("Previous Page", i, i == 1 ? i : i - 1))
+                    .replace(CURRENT, createElement("Current Page", i, i))
+                    .page(elements.subList((i - 1) * capacity, i == pages ? elements.size() : i * capacity))
+                    .build()));
         }
         return this;
     }
 
     /**
-     * Opens the first page for this player.
-     *
-     * @param player the player
+     * Creates an element for a certain page number and target page.
      */
-    public void open(Player player) {
-        views.get(0).open(player);
+    private Element createElement(String name, int page, int target) {
+        ItemStack item = ItemStack.builder()
+                .itemType(page == target ? ItemTypes.MAP : ItemTypes.PAPER)
+                .add(Keys.DISPLAY_NAME, Text.of(name, " (", target, ")"))
+                .quantity(page)
+                .build();
+        return page == target ? Element.of(item) : Element.of(item, a -> views.get(page - 1).open(a.getPlayer()));
+    }
+
+    /**
+     * Opens the given page for the player. Pages are indexed starting at 1. If
+     * the index is out of bounds, the closed valid page will be opened.
+     */
+    public void open(Player player, int page) {
+        views.get((page > 1 ? Math.min(page, views.size()) - 1 : 0)).open(player);
+    }
+
+    /**
+     * Creates a new builder for creating {@link Page}s.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private InventoryArchetype archetype = InventoryArchetypes.DOUBLE_CHEST;
+        private List<InventoryProperty> properties = Lists.newArrayList();
+        private Layout layout;
+
+        /**
+         * Sets the archetype used for the backing {@link View}s.
+         */
+        public Builder archetype(InventoryArchetype archetype) {
+            this.archetype = archetype;
+            return this;
+        }
+
+        /**
+         * Adds a property used for the backing {@link View}s.
+         */
+        public Builder property(InventoryProperty property) {
+            properties.add(property);
+            return this;
+        }
+
+        /**
+         * Sets the layout used for the template of this view. It is expected
+         * that the layout contains empty slots.
+         */
+        public Builder layout(Layout layout) {
+            this.layout = layout;
+            return this;
+        }
+
+        /**
+         * @return the created page
+         */
+        public Page build(PluginContainer container) {
+            Preconditions.checkState(layout != null, "layout");
+            return new Page(archetype, ImmutableList.copyOf(properties), layout, container);
+        }
+
     }
 
 }

--- a/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Page.java
+++ b/TeslaLibs/src/main/java/com.mcsimonflash.sponge.teslalibs/inventory/Page.java
@@ -62,8 +62,7 @@ public class Page {
             View.Builder builder = View.builder().archetype(archetype);
             properties.forEach(builder::property);
             views.add(builder.build(container).define(Layout.builder()
-                    .dimension(layout.getDimension())
-                    .setAll(layout.getElements())
+                    .from(layout)
                     .replace(FIRST, createElement("First Page", i, 1))
                     .replace(LAST, createElement("Last Page", i, pages))
                     .replace(NEXT, createElement("Next Page", i, i == pages ? i : i + 1))
@@ -82,9 +81,9 @@ public class Page {
         ItemStack item = ItemStack.builder()
                 .itemType(page == target ? ItemTypes.MAP : ItemTypes.PAPER)
                 .add(Keys.DISPLAY_NAME, Text.of(name, " (", target, ")"))
-                .quantity(page)
+                .quantity(target)
                 .build();
-        return page == target ? Element.of(item) : Element.of(item, a -> views.get(page - 1).open(a.getPlayer()));
+        return page == target ? Element.of(item) : Element.of(item, a -> open(a.getPlayer(), target));
     }
 
     /**


### PR DESCRIPTION
This PR refactors the Inventory library to support more advanced actions for working with inventories, fixes some of the limitations of the previous iteration, and makes a series of (breaking) changes to aim for a more consistent and stable API moving forward.

***

### Design Goals

* To support dynamic inventories (such as trade windows), the `Element` should be able to allow the transaction of an event to proceed.
* An `Element` should be able to filter out different types of events (ideally through different consumers in the builder).
* A layout should contain an `InventoryDimension` as it is reasonably dependent on the dimension of the backing inventory to be displayed properly
* The `View` class should allow user defined `InventoryProperty`s, notably `InventoryTitle`.
* The `closeable` aspect of `View`s needs to be properly implemented.
* The `Page` class should support multiple `InventoryArchetype`s.
* Consideration for main inventory support, such as `Element`s attached to the player's hotbar or inventory (perhaps for menus or custom item slots).

### Actions

The `Action<T>` class is the largest change to the API and represents an action upon a `View` that may be processed by an `Element`. It contains the `InteractInventoryEvent` that caused the action as well as the `Player` responsible.

The `Action.Click` class extends `Action<ClickInventoryEvent>`, and is intended to eventually support generics for further subclasses (for now, manual checking is required). It contains both the `Element` that is currently processing the action and the `Slot` obtained from the event transaction.

The `View` class also has a `closeAction` that can processed when the inventory is closed - this is a replaced of the previous `closable` setting that can also handle other actions.

### View & Page

The `View` and `Page` classes have both received builders that allow you to specify custom `InventoryArchetype`s and `InventoryProperty`s used for their backing inventories. This can be used to change things such as the size of pages or the title of a `View`'s inventory.

### Layout Dimension

It is my believe that a layout of an inventory is highly related to the dimension of it, and multiple methods in the previous API made use of it for advanced layout designs. However, the `Layout` class itself did not require a dimension to be used in most(?) scenarios. This design contains a bit of a compromise - an `InventoryDimension` is required, but it defaults to that of a double chest (6 by 9). This should still allow the `Layout` class to be used without setting a dimension if need be.

It was also previously possible to set inaccessible indices on a `Layout`, which has been removed as a result with some restrictions on the current dimension. However, because the dimension is effectively optional, it is not possible to check if the dimension of the `Layout` matches the dimension of the backing inventory. This could result in odd results and might be nice to check for and fail fast on.

### Menu Support

I have had discussion about support of a menu that can be applied to a player's hotbar/inventory. While this is not the focus of this PR (though may be included if feasible), I would still like to consider possible implementation details to ensure it can be done without any breaking changes. If you have thoughts on this, please leave them below.

### Feedback

This PR contains a lot of breaking changes, and I feel as if I may have been too lenient with them under the guise of this being one of the first libraries in TeslaLibs and not as well written or designed as more recent ones. I would like to get your feedback on the overall design of this API, what types of features you'd like to see in this PR or a future update, and any ideas you have for making the design of this much cleaner.