### PR TITLE
Added sources jar for JitPack, closes SimonFlash/TeslaPowered#6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,18 +3,13 @@ plugins {
     id "com.github.johnrengelman.shadow" version "1.2.4"
 }
 
-allprojects {
-    ext.version = "1.1.1"
-}
-
 group "com.mcsimonflash.sponge.teslapowered"
-version = ext.version
 
 allprojects {
     apply plugin: "java"
     apply plugin: "org.spongepowered.plugin"
 
-    version = ext.version
+    version = "1.1.1"
 
     dependencies {
         compile "org.spongepowered:spongeapi:7.1.0-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,32 @@
 plugins {
-    id 'org.spongepowered.plugin' version '0.8.1'
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id "org.spongepowered.plugin" version "0.8.1"
+    id "com.github.johnrengelman.shadow" version "1.2.4"
 }
 
-group 'com.mcsimonflash.sponge.teslapowered'
-version '1.1.1'
-ext.spongeversion = '7.1.0-SNAPSHOT'
+allprojects {
+    ext.version = "1.1.1"
+}
+
+group "com.mcsimonflash.sponge.teslapowered"
+version = ext.version
 
 allprojects {
-    apply plugin: 'java'
-    apply plugin: 'org.spongepowered.plugin'
+    apply plugin: "java"
+    apply plugin: "org.spongepowered.plugin"
+
+    version = ext.version
+
     dependencies {
-        compile "org.spongepowered:spongeapi:${spongeversion}"
+        compile "org.spongepowered:spongeapi:7.1.0-SNAPSHOT"
     }
-    jar {
-        archiveName = "${project.name}-s${spongeversion.substring(0, 3)}-v${this.version}.jar"
+
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        from allprojects.collect { it.sourceSets.main.allSource }
+        classifier = "sources"
+    }
+
+    artifacts {
+        archives sourcesJar
     }
 }
 
@@ -28,11 +40,11 @@ shadowJar {
         include project(":TeslaCore")
         include project(":TeslaLibs")
     }
-    archiveName = "${project.name}-s${spongeversion.substring(0, 3)}-v${version}.jar"
+    classifier = null
 }
 
 task copyJars(type: Copy) {
-    from([subprojects.jar, shadowJar])
+    from([allprojects.jar, shadowJar])
     into project.file("#releases/${version}")
 }
 


### PR DESCRIPTION
- Added the creation of the related sources jars
- TeslaCore and TeslaLib sources generate fine
- TeslaPowered(the parent project) only has an empty source jar, but that's ok since the IDE always picks TeslaCore or TeslaLib anyways
- The fancy name with the sponge version got lost since `archiveName` doesn't work well with jitpack artifacts for some reason, one could add the sponge version to the project version like `version = 1.1.1-s7.1` to work around that.
- Updated the shadow plugin