### PR TITLE
Added generation of sources jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 group 'com.mcsimonflash.sponge.teslapowered'
 version '1.1.1'
 ext.spongeversion = '7.1.0-SNAPSHOT'
+version "s${spongeversion[0..2]}-v${version}"
 
 allprojects {
     apply plugin: 'java'
@@ -13,9 +14,14 @@ allprojects {
     dependencies {
         compile "org.spongepowered:spongeapi:${spongeversion}"
     }
-    jar {
-        archiveName = "${project.name}-s${spongeversion.substring(0, 3)}-v${this.version}.jar"
+
+    version = rootProject.version
+
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        from sourceSets.main.allSource
+        classifier = "sources"
     }
+    artifacts.archives sourcesJar
 }
 
 dependencies {
@@ -28,7 +34,7 @@ shadowJar {
         include project(":TeslaCore")
         include project(":TeslaLibs")
     }
-    archiveName = "${project.name}-s${spongeversion.substring(0, 3)}-v${version}.jar"
+    classifier = null // removes the '-all' ending
 }
 
 task copyJars(type: Copy) {


### PR DESCRIPTION
`compile "com.github.randombyte-developer:TeslaPowered:7f90d24de5"` for testing.

One thing: The `#releases` folder now has the version like `s7.1-v1.1.1` instead of `1.1.1`. Either you like it or the actual version has to be in a separate variable for the `copyJars` task.

I tried to change as few as possible.