### PR TITLE
Add tweaks for custom page items

### DIFF
--- a/TeslaLibs/src/main/java/com/mcsimonflash/sponge/teslalibs/inventory/CreateElement.java
+++ b/TeslaLibs/src/main/java/com/mcsimonflash/sponge/teslalibs/inventory/CreateElement.java
@@ -1,0 +1,22 @@
+package com.mcsimonflash.sponge.teslalibs.inventory;
+
+/**
+ * Created by Frani on 15/01/2019.
+ */
+@FunctionalInterface
+public interface CreateElement {
+
+    /**
+     * Used to replace a {@link Page}'s page button depending of
+     * it's current and target page. Take a look at the default {@link Page.Builder}
+     * implementation of this function.
+     *
+     * @param page The page holding this element
+     * @param element The element that is going to be replaced by this
+     * @param currentPage The current page index
+     * @param targetPage The target page index
+     * @return a new {@link Element} with customized actions
+     */
+    Element createElement(Page page, Element element, int currentPage, int targetPage);
+
+}

--- a/TeslaLibs/src/main/java/com/mcsimonflash/sponge/teslalibs/inventory/Element.java
+++ b/TeslaLibs/src/main/java/com/mcsimonflash/sponge/teslalibs/inventory/Element.java
@@ -4,6 +4,7 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class Element {
 


### PR DESCRIPTION
I had an issue where I couldn't dynamically set the name of the inventory of each view of a Page, nor set a custom item/action to the default page elements. This PR adds those. 

I added a new `CreateElement` functional interface that developers can override and return elements based on the page index, target page index and element type. It can be set via `Page.Builder#supplyElement()`. 

I added as well a `Page.Builder#supplyTitle()` so developers can dynamically set the title of an inventory based on the index of a page.